### PR TITLE
Changed 'am' to 'an'

### DIFF
--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -115,7 +115,7 @@ def parse_unspecified_argument_list(unknowns: list, multiple: bool = False, err:
 
 	To a certain extent, multiple and error are incompatible. In fact, the only error this routine can catch, as of now,
 	is the event argument value value ...
-	which isn't am error if multiple is specified
+	which isn't an error if multiple is specified
 	"""
 	tmp_list = [arg for arg in unknowns if arg != "="]  # wastes a few bytes, but avoids any collateral effect of the destructive nature of the pop method()
 	config = {}


### PR DESCRIPTION
- This fix issue: <!-- #13, #15 and #16 for instance. Or ignore if you're adding new functionality -->

## PR Description:
Changed 'am' to 'an'
<!-- Please describe what changes this PR introduces, a good example would be: https://github.com/archlinux/archinstall/pull/1377 -->

## Tests and Checks
- [x] I have tested the code!<br>
  <!--
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
